### PR TITLE
Openapi geemus proposal

### DIFF
--- a/openapi/openapi.yml
+++ b/openapi/openapi.yml
@@ -1861,7 +1861,7 @@ components:
     Reference:
       description: Resource ID or name
       type: string
-      pattern: '^[a-zA-Z0-9](?:[a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?$'
+      pattern: '^[a-z0-9](?:[a-z0-9\-]{0,61}[a-z0-9])?$'
     Vm:
       type: object
       properties:

--- a/routes/project/location/firewall.rb
+++ b/routes/project/location/firewall.rb
@@ -112,16 +112,5 @@ class Clover
         end
       end
     end
-
-    # 204 response for invalid names
-    r.is String do |firewall_name|
-      r.post do
-        Validation.validate_name(firewall_name)
-      end
-
-      r.delete do
-        204
-      end
-    end
   end
 end

--- a/routes/project/location/load_balancer.rb
+++ b/routes/project/location/load_balancer.rb
@@ -108,14 +108,5 @@ class Clover
         Serializers::LoadBalancer.serialize(lb.reload, {detailed: true})
       end
     end
-
-    # 204 response for invalid names
-    r.is String do |lb_name|
-      r.post { load_balancer_post(lb_name) }
-
-      r.delete do
-        204
-      end
-    end
   end
 end

--- a/routes/project/location/postgres.rb
+++ b/routes/project/location/postgres.rb
@@ -267,16 +267,5 @@ class Clover
         certs
       end
     end
-
-    # 204 response for invalid names
-    r.is String do |pg_name|
-      r.post do
-        postgres_post(pg_name)
-      end
-
-      r.delete do
-        204
-      end
-    end
   end
 end

--- a/routes/project/location/private_subnet.rb
+++ b/routes/project/location/private_subnet.rb
@@ -91,16 +91,5 @@ class Clover
         204
       end
     end
-
-    # 204 response for invalid names
-    r.is String do |ps_name|
-      r.post do
-        private_subnet_post(ps_name)
-      end
-
-      r.delete do
-        204
-      end
-    end
   end
 end

--- a/routes/project/location/vm.rb
+++ b/routes/project/location/vm.rb
@@ -46,14 +46,5 @@ class Clover
         end
       end
     end
-
-    # 204 response for invalid names
-    r.is String do |vm_name|
-      r.post { vm_post(vm_name) }
-
-      r.delete do
-        204
-      end
-    end
   end
 end

--- a/spec/routes/api/project/location/firewall_spec.rb
+++ b/spec/routes/api/project/location/firewall_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe Clover, "firewall" do
     it "get does not exist for invalid name" do
       get "/project/#{project.ubid}/location/#{TEST_LOCATION}/firewall/foo_name"
 
-      expect(last_response).to have_api_error(404, 'Parameter "foo_name" does not match pattern ^[a-zA-Z0-9](?:[a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?$')
+      expect(last_response).to have_api_error(404, 'Parameter "foo_name" does not match pattern ^[a-z0-9](?:[a-z0-9\-]{0,61}[a-z0-9])?$')
     end
 
     it "get does not exist for valid name" do
@@ -80,7 +80,7 @@ RSpec.describe Clover, "firewall" do
         description: "Firewall description"
       }.to_json
 
-      expect(last_response).to have_api_error(400, "Validation failed for following fields: name")
+      expect(last_response).to have_api_error(404, 'Parameter "FooName" does not match pattern ^[a-z0-9](?:[a-z0-9\-]{0,61}[a-z0-9])?$')
     end
 
     it "success delete with underscore" do

--- a/spec/routes/api/project/location/load_balancer_spec.rb
+++ b/spec/routes/api/project/location/load_balancer_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe Clover, "load-balancer" do
       it "not found" do
         get "/project/#{project.ubid}/location/#{TEST_LOCATION}/load-balancer/_invalid"
 
-        expect(last_response).to have_api_error(404, 'Parameter "_invalid" does not match pattern ^[a-zA-Z0-9](?:[a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?$')
+        expect(last_response).to have_api_error(404, 'Parameter "_invalid" does not match pattern ^[a-z0-9](?:[a-z0-9\-]{0,61}[a-z0-9])?$')
       end
     end
 

--- a/spec/routes/api/project/location/postgres_spec.rb
+++ b/spec/routes/api/project/location/postgres_spec.rb
@@ -145,7 +145,7 @@ RSpec.describe Clover, "postgres" do
           ha_type: "sync"
         }.to_json
 
-        expect(last_response).to have_api_error(400, "Validation failed for following fields: name", {"name" => "Name must only contain lowercase letters, numbers, and hyphens and have max length 63."})
+        expect(last_response).to have_api_error(404, 'Parameter "INVALIDNAME" does not match pattern ^[a-z0-9](?:[a-z0-9\-]{0,61}[a-z0-9])?$')
       end
 
       it "can update database properties" do

--- a/spec/routes/api/project/location/private_subnet_spec.rb
+++ b/spec/routes/api/project/location/private_subnet_spec.rb
@@ -93,7 +93,7 @@ RSpec.describe Clover, "private_subnet" do
       it "invalid name" do
         post "/project/#{project.ubid}/location/#{TEST_LOCATION}/private-subnet/invalid_name"
 
-        expect(last_response).to have_api_error(404, 'Parameter "invalid_name" does not match pattern ^[a-zA-Z0-9](?:[a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?$')
+        expect(last_response).to have_api_error(404, 'Parameter "invalid_name" does not match pattern ^[a-z0-9](?:[a-z0-9\-]{0,61}[a-z0-9])?$')
       end
 
       it "not authorized" do

--- a/spec/routes/api/project/location/vm_spec.rb
+++ b/spec/routes/api/project/location/vm_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe Clover, "vm" do
       it "ubid not exist" do
         get "/project/#{project.ubid}/location/#{vm.display_location}/vm/_foo_ubid"
 
-        expect(last_response).to have_api_error(404, 'Parameter "_foo_ubid" does not match pattern ^[a-zA-Z0-9](?:[a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?$')
+        expect(last_response).to have_api_error(404, 'Parameter "_foo_ubid" does not match pattern ^[a-z0-9](?:[a-z0-9\-]{0,61}[a-z0-9])?$')
       end
 
       it "location not exist" do
@@ -171,7 +171,7 @@ RSpec.describe Clover, "vm" do
           enable_ip4: true
         }.to_json
 
-        expect(last_response).to have_api_error(400, "Validation failed for following fields: name", {"name" => "Name must only contain lowercase letters, numbers, and hyphens and have max length 63."})
+        expect(last_response).to have_api_error(404, 'Parameter "MyVM" does not match pattern ^[a-z0-9](?:[a-z0-9\-]{0,61}[a-z0-9])?$')
       end
 
       it "invalid boot image" do


### PR DESCRIPTION
I didn't do a good job with the commit messages here, but this does make the coverage pass: the fall-through case code in the app was eliminated. Some tests had invalid names in forms that would fall through committee to be handled by Ruby, which applied a different regexp, and then *its* fallthrough would result in an error...and different code coverage/paths.

By harmonizing the two regexp sites, going into committee only to hit the fall-through path in Ruby never happens.

The ruby definition is here:

```ruby
class Clover < Roda
  def self.name_or_ubid_for(model)
    # (\z)? to force a nil as first capture
    [/(\z)?(#{model.ubid_type}[a-tv-z0-9]{24})/, /([a-z0-9](?:[a-z0-9\-]{0,61}[a-z0-9])?)/]
  end
  [Firewall, KubernetesCluster, LoadBalancer, PostgresResource, PrivateSubnet, Vm].each do |model|
    const_set(:"#{model.table_name.upcase}_NAME_OR_UBID", name_or_ubid_for(model))
  end
```

In principle these two regexps have an opportunity to drift, but I think in practice, our identifier situation will settle down.

@jeremyevans suggests that `400` to match other validation errors would be preferred to 404, I guess that makes sense: sure, the object is not there on account of its name, but furthermore, it can _never_ be there, so 400 seems appropriate, since the request is semantically bogus. It also is consistent with other validation problems.

I tried applying the following patch to get a feel for doing things that way (in this arm of the code, the default situation is 400), and something unusual happened, I am wondering if you know what's up there:

```diff
diff --git a/clover.rb b/clover.rb
index 820c8123..908aa3a6 100644
--- a/clover.rb
+++ b/clover.rb
@@ -183,8 +183,6 @@ def assets
       when OpenAPIParser::InvalidPattern
         pattern = e.original_error.instance_variable_get(:@pattern)
         value = e.original_error.instance_variable_get(:@value)
-        code = 404
-        type = "ResourceNotFound"
         message = "Parameter #{value.inspect} does not match pattern #{pattern}"
       when OpenAPIParser::NotExistPropertyDefinition
         keys = e.original_error.instance_variable_get(:@keys)
```

What I expected to happen is exception conversion would result in http error codes, but instead, the committee exception is raised instead. I did not set `SHOW_ERRORS`.

```
  11) Clover private_subnet authenticated delete not exist for invalid name
      Failure/Error: delete "/project/#{project.ubid}/location/#{ps.display_location}/private-subnet/foo_name"
      
      Committee::InvalidRequest:
        #/components/schemas/Reference pattern ^[a-z0-9](?:[a-z0-9\-]{0,61}[a-z0-9])?$ does not match value: "foo_name"
      # ./clover.rb:692:in `block in <class:Clover>'
      # ./clover.rb:28:in `call'
      # ./spec/routes/api/project/location/private_subnet_spec.rb:217:in `block (4 levels) in <top (required)>'
      # ./spec/spec_helper.rb:51:in `block (3 levels) in <top (required)>'
      # ./spec/spec_helper.rb:50:in `block (2 levels) in <top (required)>'
      # ------------------
      # --- Caused by: ---
      # Committee::InvalidRequest:
      #   #/components/schemas/Reference pattern ^[a-z0-9](?:[a-z0-9\-]{0,61}[a-z0-9])?$ does not match value: "foo_name"
      #   ./clover.rb:692:in `block in <class:Clover>'
```

Besides this, I guess it's plausible that I should only leave it as 400 when it's a `Reference` component that is malformed, depending on how patterns are used throughout openapi...but I wanted to resolve my exception mystery first.